### PR TITLE
Still send movement change if server

### DIFF
--- a/Scripts/GameApi/LiteNetLibTransform.cs
+++ b/Scripts/GameApi/LiteNetLibTransform.cs
@@ -136,7 +136,7 @@ namespace LiteNetLibManager
         private void ClientSendTransform(TransformResult transformResult)
         {
             // Don't request to set transform if not set "canClientSendResult" to TRUE
-            if (!ownerClientCanSendTransform || !IsOwnerClient || IsServer)
+            if (!ownerClientCanSendTransform || !IsOwnerClient)
                 return;
             Manager.ClientSendPacket(sendOptions, LiteNetLibGameManager.GameMsgTypes.ClientSendTransform, (writer) => ClientSendTransformWriter(writer, transformResult));
         }


### PR DESCRIPTION
If you toggled `ownerClientCanSendTransform` to true, the server would not send out transform updates, even though the server was the ownerClient.
This fixes that, since the transform script returned if we were the server. I take it assumed that the ownerClient would never be the server, which can be the case.
This is of course tested and working.